### PR TITLE
Add smoke test to App Runner deploy workflow

### DIFF
--- a/.github/workflows/deploy-app-runner.yml
+++ b/.github/workflows/deploy-app-runner.yml
@@ -40,3 +40,22 @@ jobs:
 
       - name: App Runner output
         run: echo "App runner output ${{ steps.deploy-apprunner.outputs.service-id }}"
+
+      - name: Test actuator endpoints
+        run: |
+          set -e
+          SERVICE_URL=${{ steps.deploy-apprunner.outputs.service-url }}
+
+          for i in {1..30}; do
+            if curl -fs "$SERVICE_URL/public/actuator/health" | grep -q '"status":"UP"'; then
+              if curl -fs "$SERVICE_URL/public/actuator/info" | grep -q "${{ env.IMAGE_TAG }}"; then
+                echo "✅ Actuator endpoints OK"
+                exit 0
+              fi
+            fi
+            echo "Waiting the service to start… ($i/30)"
+            sleep 1
+          done
+
+          echo "The service did not respond"
+          exit 1


### PR DESCRIPTION
## Summary
- extend the deploy to App Runner workflow with a smoke test step

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687962be27c48325804962d28d6580e6