### PR TITLE
Fix kubeconfig action name

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -34,7 +34,7 @@ jobs:
           eksctl create cluster --name "$CLUSTER_NAME" --region ${{ vars.AWS_REGION }}
 
       - name: Update kubeconfig
-        uses: aws-actions/eks-update-kubeconfig@v2
+        uses: aws-actions/amazon-eks-update-kubeconfig@v2
         with:
           cluster-name: ${{ vars.EKS_CLUSTER }}
           region: ${{ vars.AWS_REGION }}


### PR DESCRIPTION
## Summary
- replace deprecated `aws-actions/eks-update-kubeconfig@v2` with `aws-actions/amazon-eks-update-kubeconfig@v2`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68840b28de148325ae8b0f818024291f