### PR TITLE
Expose service externally via LoadBalancer

### DIFF
--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -3,12 +3,11 @@ kind: Service
 metadata:
   name: connect4-java
 spec:
-  type: NodePort
+  type: LoadBalancer
   selector:
     app: connect4-java
   ports:
     - port: 8080
-      nodePort: 30001
       protocol: TCP
       targetPort: 8080
-  
+


### PR DESCRIPTION
## Summary
- expose Kubernetes Service via a LoadBalancer

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6887728fb2208325b4e99d0d9d4f9efb