### PR TITLE
Add smoke test after EKS deployment

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -43,3 +43,25 @@ jobs:
         run: |
           kubectl apply -f k8s/
           kubectl set image deployment/connect4-java connect4-java=docker.io/biplopdey/connect4-java:${{ env.IMAGE_TAG }}
+
+      - name: Wait for service URL
+        id: service
+        run: |
+          set -e
+          for i in {1..60}; do
+            HOST=$(kubectl get svc connect4-java -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+            if [ -n "$HOST" ]; then
+              echo "url=http://$HOST" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Waiting for service… ($i/60)"
+            sleep 5
+          done
+          echo "Service load balancer hostname not available" >&2
+          exit 1
+
+      - name: Test actuator endpoints
+        uses: ./.github/actions/smoke-test
+        with:
+          url: ${{ steps.service.outputs.url }}
+          version: ${{ env.IMAGE_TAG }}


### PR DESCRIPTION
## Summary
- trigger a post-deployment smoke test in `deploy-eks.yml`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6887938ad2188325a6b466c601af8fd2