### PR TITLE
Update CI workflow to trigger only on source changes

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,6 +1,10 @@
 name: Pmd,Test,Sonar, build and push jar to artifactory
 run-name: running spring boot version
-on: [ push ]
+on:
+  push:
+    paths:
+      - 'src/**'
+      - 'pom.xml'
 jobs:
   pmd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- only run `test-ci.yml` workflow when `src` or `pom.xml` change

## Testing
- `mvn --batch-mode test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6888b0de1124832592b25a3e5927fcef