### PR TITLE
Add pull_request trigger for CI

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'src/**'
       - 'pom.xml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'pom.xml'
 jobs:
   pmd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure `test-ci` workflow runs for pull requests as well as pushes

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888b64d608c83258a568331a7a6e7c9