### PR TITLE
Simplify and modernize EKS deployment workflow

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: ${{ github.event.inputs.version }}
+      IMAGE: docker.io/biplopdey/connect4-java:${{ github.event.inputs.version }}
       CLUSTER_NAME: ${{ vars.EKS_CLUSTER }}
     steps:
       - uses: actions/checkout@v4
@@ -22,35 +23,19 @@ jobs:
       - name: Deploy to local cluster
         run: |
           kubectl apply -f k8s/
-          kubectl set image deployment/connect4-java connect4-java=docker.io/biplopdey/connect4-java:${{ env.IMAGE_TAG }}
+          kubectl set image deployment/connect4-java connect4-java=${{ env.IMAGE }}
           kubectl wait --for=condition=available --timeout=90s deployment/connect4-java
 
-      - name: Smoke test locally
-        shell: bash
+      - name: Port forward service
         run: |
-          ensure_port_forward() {
-            if [ ! -f /tmp/pf.pid ] || ! ps -p "$(cat /tmp/pf.pid)" > /dev/null 2>&1; then
-              kubectl port-forward service/connect4-java 8080:8080 >/tmp/pf.log 2>&1 &
-              echo $! > /tmp/pf.pid
-            fi
-          }
-          ensure_port_forward
-          trap 'kill $(cat /tmp/pf.pid) 2>/dev/null' EXIT
-          URL="http://localhost:8080"
-          VERSION="${IMAGE_TAG}"
-          for i in {1..30}; do
-            ensure_port_forward
-            if curl -fs "$URL/public/actuator/health" | grep -q '"status":"UP"'; then
-              if curl -fs "$URL/public/actuator/info" | grep -q "$VERSION"; then
-                echo "✅ Actuator endpoints OK"
-                exit 0
-              fi
-            fi
-            echo "Waiting the service to start… ($i/30)"
-            sleep 1
-          done
-          echo "The service did not respond"
-          exit 1
+          kubectl port-forward service/connect4-java 8080:8080 >/tmp/pf.log 2>&1 &
+          echo $! > /tmp/pf.pid
+
+      - name: Smoke test locally
+        uses: ./.github/actions/smoke-test
+        with:
+          url: http://localhost:8080
+          version: ${{ env.IMAGE_TAG }}
 
       - name: Cleanup local cluster
         if: always()
@@ -67,9 +52,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Install eksctl
-        run: |
-          curl --location "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+        uses: aws-actions/amazon-eks-eksctl@v1
 
       - name: Create EKS cluster if needed
         run: |
@@ -77,15 +60,15 @@ jobs:
           eksctl create cluster --name "$CLUSTER_NAME" --region ${{ vars.AWS_REGION }}
 
       - name: Update kubeconfig
-        run: |
-          aws eks update-kubeconfig \
-            --name "$CLUSTER_NAME" \
-            --region ${{ vars.AWS_REGION }}
+        uses: aws-actions/amazon-eks-login@v1
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ vars.AWS_REGION }}
 
       - name: Apply manifests
         run: |
           kubectl apply -f k8s/
-          kubectl set image deployment/connect4-java connect4-java=docker.io/biplopdey/connect4-java:${{ env.IMAGE_TAG }}
+          kubectl set image deployment/connect4-java connect4-java=${{ env.IMAGE }}
 
       - name: Wait for service URL
         id: service


### PR DESCRIPTION
## Summary
- reuse smoke-test action for local checks via port-forward
- use official AWS actions for eksctl installation and login
- centralize image reference and other minor cleanups

## Testing
- `bash mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a50411a04083258938e7af20728ac4