### PR TITLE
Fix port-forwarding in local k8s test workflow

### DIFF
--- a/.github/workflows/local-k8s-test.yml
+++ b/.github/workflows/local-k8s-test.yml
@@ -36,8 +36,14 @@ jobs:
             sleep 1
           done
 
-          # Find the target pod and start port-forward in background
-          POD_NAME=$(kubectl get pods -l app=connect4-java -o jsonpath='{.items[0].metadata.name}')
+          # Find a running target pod and start port-forward in background
+          POD_NAME=$(kubectl get pods -l app=connect4-java --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$POD_NAME" ]; then
+            echo "No running pod found for connect4-java"
+            kubectl get pods -l app=connect4-java
+            exit 1
+          fi
+
           kubectl port-forward pod/$POD_NAME 8080:8080 >/tmp/pf.log 2>&1 &
           echo $! > /tmp/pf.pid
 

--- a/.github/workflows/local-k8s-test.yml
+++ b/.github/workflows/local-k8s-test.yml
@@ -36,8 +36,9 @@ jobs:
             sleep 1
           done
 
-          # Start port-forward in background and capture PID
-          kubectl port-forward service/connect4-java 8080:8080 >/tmp/pf.log 2>&1 &
+          # Find the target pod and start port-forward in background
+          POD_NAME=$(kubectl get pods -l app=connect4-java -o jsonpath='{.items[0].metadata.name}')
+          kubectl port-forward pod/$POD_NAME 8080:8080 >/tmp/pf.log 2>&1 &
           echo $! > /tmp/pf.pid
 
           # Wait until port-forward reports it's listening or the process exits


### PR DESCRIPTION
## Summary
- Port-forward directly to the pod in local-k8s-test workflow for more reliable connections

## Testing
- `pip install yamllint` *(failed: Could not find a version that satisfies the requirement yamllint)*
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b865bee1a88325b307755b776426a0